### PR TITLE
add-request-timeout

### DIFF
--- a/mssql.html
+++ b/mssql.html
@@ -40,6 +40,10 @@
         <input type="text" id="node-config-input-database">
     </div>
     <div class="form-row">
+        <label for="node-config-input-database"><i class="fa fa-user"></i> Request Timeout (ms)</label>
+        <input type="text" id="node-config-input-requestTimeout">
+    </div>
+    <div class="form-row">
         <label for="node-config-input-encyption"><i class="fa fa-user"></i> Use Encryption?</label>
         <input type="checkbox" id="node-config-input-encyption">
         <div class="form-tips">SQL Databases hosted on Azure will need this checked</div>
@@ -53,7 +57,8 @@
             name: {value:""},
             server: {value:""},
             encyption:{value:true},
-            database: {value:""}
+            database: {value:""},
+            requestTimeout: {value:15000}
         },
         inputs:0,
         outputs:0,

--- a/mssql.js
+++ b/mssql.js
@@ -10,9 +10,10 @@ module.exports = function(RED) {
 	    this.config = {
             user: node.credentials.username,
             password: node.credentials.password,
-						domain: node.credentials.domain,
+            domain: node.credentials.domain,
             server: config.server,
             database: config.database,
+            requestTimeout: config.requestTimeout,
             options: {
                            encrypt : config.encyption,
                            useUTC: config.useUTC


### PR DESCRIPTION
Allow node-red users to specify request timeout for mussel commands.
This is necessary if a command takes longer than 15 seconds.